### PR TITLE
Custom keys

### DIFF
--- a/bibsearch.py
+++ b/bibsearch.py
@@ -114,11 +114,9 @@ class BibDB:
                             [" ".join(query)])
         return self.cursor
 
-    def search_strict(self, column_values):
-        query = ' AND '.join(["%s=?" % cv[0] for cv in column_values])
-        # This query building is done inside the programm, it should be safe!
-        self.cursor.execute("SELECT fulltext FROM bib WHERE %s" % query, # This is safe!
-                            [cv[1] for cv in column_values])
+    def search_key(self, key):
+        self.cursor.execute("SELECT fulltext FROM bib WHERE key=? OR custom_key=?",
+                            [key, key])
         return self.cursor
 
     def save(self):
@@ -297,7 +295,7 @@ def _tex(args):
         match = citation_re.match(l)
         if match:
             key = match.group(1)
-            bib_entry = db.search_strict([("key", key)]).fetchone()
+            bib_entry = db.search_key(key).fetchone()
             if bib_entry:
                 entries.append(bib_entry[0])
             else:


### PR DESCRIPTION
Support for custom keys:

```
$ /usr/local/opt/python3/bin/python3 ./bibsearch.py search matt post wmt
[weese11_joshua] Weese, Jonathan and Ganitkevitch, Juri and Callison-
  Burch, Chris and Post, Matt and Lopez, Adam "Joshua 3.0: Syntax-
  based Machine Translation with the Thrax Grammar Extractor", WMT
  2011

[callison-burch12_findings] Callison-Burch, Chris and Koehn, Philipp
  and Monz, Christof and Post, Matt and Soricut, Radu and Specia,
  Lucia "Findings of the 2012 Workshop on Statistical Machine
  Translation", WMT 2012

[ganitkevitch12_joshua] Ganitkevitch, Juri and Cao, Yuan and Weese,
  Jonathan and Post, Matt and Callison-Burch, Chris "Joshua 4.0:
  Packing, PRO, and Paraphrases", WMT 2012

...
```
User defined keys can be specified with the `key` command.

In addition: better support for events and better text formatting (expand TeX commands).