### PR TITLE
Adding a crawl command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+\.idea/
+
+__pycache__/

--- a/bibdb.py
+++ b/bibdb.py
@@ -3,6 +3,7 @@ import os.path
 import pybtex.database as pybtex
 import sqlite3
 import yaml
+import sys
 
 from typing import Tuple
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires = ['typing', 'tqdm', 'pyaml', 'stop-words', 'pybtex', 'feedparser'],
+    install_requires = ['typing', 'tqdm', 'pyaml', 'stop-words', 'pybtex', 'feedparser', 'textract'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Adding a command to crawl bib entries from a URL (links to pdf files and bib files).

I couldn't check the preference for the ACL anthology (or any other downloaded sources) for papers taken from arXiv and Semantic Scholar, because I couldn't make fts5 work in my environment (so searching by title is disabled).