### PR TITLE
Open from search

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ If there is only one match, you can also open the corresponding PDF:
 
     bibsearch open
 
+If there are multiple matches, `open` will open the top result:
+
+    bibsearch open embedding
+
 Generate the BibTeX file based on citations found in a LaTeX source (requires that `LATEX_FILE.aux` exists):
 
     bibsearch tex LATEX_FILE

--- a/bibsearch/bibsearch.py
+++ b/bibsearch/bibsearch.py
@@ -213,11 +213,12 @@ def _get_cache_or_search_result(db: BibDB,
         entry_index = int(search_terms[0]) - 1
 
     else:
-        results = db.search(args.terms)
-
+        results = db.search(search_terms)
         if not results:
             logging.error("Search returned no results.")
             sys.exit(1)
+
+        entry_index = 0
 
     if entry_index >= len(results):
         logging.error("You requested result {}, but only {} documents were found.".format(entry_index, len(results)))
@@ -248,7 +249,7 @@ def _open(args, config):
         if not os.path.exists(config.download_dir):
             os.makedirs(config.download_dir)
         pdf_path = download_entry(entry, config)
-        subprocess.run([config.open_command, pdf_path])
+        subprocess.Popen([config.open_command, pdf_path])
 
 
 def _download(args, config):


### PR DESCRIPTION
I tried using `bibsearch open` to open the result of a query, and got this traceback:

```
$ bibsearch open "deep contextualized"
Traceback (most recent call last):
  File "/home/chris/.pyenv/versions/3.6.4/bin/bibsearch", line 11, in <module>
    load_entry_point('bibsearch==0.3.9', 'console_scripts', 'bibsearch')()
  File "/home/chris/.pyenv/versions/3.6.4/lib/python3.6/site-packages/bibsearch/bibsearch.py", line 701, in main
    args.func(args, config)
  File "/home/chris/.pyenv/versions/3.6.4/lib/python3.6/site-packages/bibsearch/bibsearch.py", line 223, in _open
    bibtex, key = _get_cache_or_search_result(db, args.terms)
  File "/home/chris/.pyenv/versions/3.6.4/lib/python3.6/site-packages/bibsearch/bibsearch.py", line 198, in _get_cache_or_search_result
    results = db.search(args.terms)
NameError: name 'args' is not defined
```