### PR TITLE
Adds support for XDG_CONFIG dirs [WIP]

### DIFF
--- a/bibsearch/bibsearch.py
+++ b/bibsearch/bibsearch.py
@@ -676,11 +676,7 @@ def main():
     parser = argparse.ArgumentParser(description="bibsearch: Download, manage, and search a BibTeX database.\nUse '%(prog)s man' to get complete help.",
                                      formatter_class=SubcommandHelpFormatter)
     parser.add_argument('--version', '-V', action='version', version='%(prog)s {}'.format(VERSION))
-    parser.add_argument('-c', '--config_file', help="use this config file",
-                        default=os.path.join(os.path.expanduser("~"),
-                                             '.bibsearch',
-                                             "config")
-                        )
+    parser.add_argument('-c', '--config_file', help="use this config file")
     parser.set_defaults(func=lambda *_ : parser.print_help())
     subparsers = parser.add_subparsers(title="commands",
                                        description="Use '%(prog)s <command> -h' to obtain additional help.",

--- a/bibsearch/config.py
+++ b/bibsearch/config.py
@@ -34,6 +34,8 @@ class Config():
         config.read_dict(self.__class__.defaults)
 
         # Override those defaults from the config file
+        if config_file is None:
+            config_file = self._check_for_existing_config()
         config.read(config_file)
 
         # Make available as member variables
@@ -44,6 +46,17 @@ class Config():
                 logging.warning("Unknown config option '%s'", k)
 
         self.macros = config["macros"]
+
+    @classmethod
+    def _check_for_existing_config(cls):
+        # the default if XDG_CONFIG_HOME isn't set is  ~/.config
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config")
+        # check there for a config file
+        if os.path.exists(os.path.join(xdg_config_home, "bibsearch/config")):
+            config_file = os.path.join(xdg_config_home, "bibsearch/config")
+        # otherwise, use ~/.bibsearch/config
+        config_file = os.path.expanduser("~/.bibsearch/config")
+        return config_file
 
     @classmethod
     def get_default(cls, key: str) -> str:


### PR DESCRIPTION
WRT Issue #35 

## What's done:
- removes default config file set in argparser
- adds method in Config for getting existing config file if arg isn't set

## What remains to be done
- support `$XDG_DATA_HOME` and `$XDG_CACHE_HOME`
- test (unit tests preferably) the various possible scenarios, if it breaks existing config setups, etc

