### PR TITLE
Support arbitrary queries in \cite commands

### DIFF
--- a/bibsearch/bibsearch.py
+++ b/bibsearch/bibsearch.py
@@ -547,11 +547,16 @@ def _tex(args, config):
         if match:
             keystr = match.group(1)
             for key in keystr.split(','):
-                bib_entry = db.search_key(key)
-                if bib_entry:
-                    entries.add(bib_entry)
-                else:
+                #bib_entry = db.search_key(key)
+                bib_entries = db.search(key.strip().replace("_", " ").split())
+                if not bib_entries:
                     logging.warning("Entry '%s' not found", key)
+                else:
+                    if len(bib_entries) > 1:
+                        logging.warning("More than one entry found for '%s', taking the first one", key)
+                    bib_entry = bibutils.single_entry_to_fulltext(bibutils.fulltext_to_single_entry(bib_entries[0][0]),
+                                                                  overwrite_key=key)
+                    entries.add(bib_entry)
         elif args.write_bibfile or args.overwrite_bibfile:
             match = bibdata_re.match(l)
             if match:


### PR DESCRIPTION
This is a proof of concept of something @mjpost wanted for some time. With this PR we can include \cite commands with arbitrary terms and `bibsearch tex` will execute a general query. E.g:

```
\cite{post_vilar_2018_constrained_decoding, brown_1993_mathematics_machine_translation}
```

The implementation is really simple and touches bibsearch only. This means that latex and bibtex see the queries as the "keys" for the bibtex entries. This has some implications that we should discuss (and are the main reason for this PR):
* As seen in the example, search terms are separated by underscores '_' to ensure that the "keys" are single tokens for bibtex. This means that keys with underscores in them (e.g. brown93_smt) will *not* work anymore in `bibsearch tex`. We do not generate keys with underscores by default, but they can be customized or manually generated.
* No test for duplicate entries is carried out. E.g. if to the document with the line above we add `\cite{post_vilar_2018}` it will generate [Post and Vilar, 2018a] and [Post and Vilar, 2018b]. If exactly the same search term is used, of course everything works fine.
* If more than one result is returned by the query, the first one is taken. Going forward we might consider failing instead.
* Of course the responsibility of specifying the search terms relies on the user (e.g. the number of entries returned may change over time). Always including a year in the search term seems like a good idea.

As said before, this is more a proof-of-concept. Probably a better solution would be to create a LaTeX package and address these issues. But I am no expert at TeX programming.

